### PR TITLE
fix for OVS-4268

### DIFF
--- a/pylabs/test/server/system_tests_common.py
+++ b/pylabs/test/server/system_tests_common.py
@@ -763,6 +763,13 @@ def setup_2_nodes_forced_master_mini (home_dir):
     extra = {'tlog_max_entries':'1000'}
     setup_n_nodes( 2, True, home_dir, extra)
 
+def setup_3_nodes_forced_master_mini_rollover_on_size(home_dir):
+    extra = {'tlog_max_entries': '100_000',
+             'tlog_max_size'   : '64000'
+            }
+    
+    setup_n_nodes( 3, True, home_dir, extra)
+    
 def setup_3_nodes_forced_master_mini (home_dir):
     extra = {'tlog_max_entries':'1000'}
     setup_n_nodes( 3, True, home_dir, extra)

--- a/src/client/remote_nodestream.ml
+++ b/src/client/remote_nodestream.ml
@@ -88,7 +88,7 @@ class remote_nodestream ((ic,oc) as conn) =
         | (-2) -> Logger.info_f_ "loop_parts done"
         | 1 ->
           begin
-            Logger.debug_f_ "loop_entries" >>= fun () ->
+            Logger.info_f_ "loop_entries" >>= fun () ->
             loop_entries () >>= fun () ->
             loop_parts ()
           end

--- a/src/main/arakoon.ml
+++ b/src/main/arakoon.ml
@@ -209,7 +209,7 @@ let main () =
   and tls_version = ref "1.0"
   and force = ref false
   and in_place = ref false
-  and archive_type = ref ".tlf"
+  and archive_type = ref ".tlx"
   and left = ref None
   and linc = ref true
   and right = ref None
@@ -279,7 +279,7 @@ let main () =
                                   Arg.Set_string filename],
      "<filename> : compress a tlog file");
     ("-archive", Arg.Set_string archive_type,
-     "either '.tlf' or '.tls'");
+     "either '.tlf' or '.tlf'");
     ("--uncompress-tlog", Arg.Tuple[set_laction UncompressTlog;
                                     Arg.Set_string filename],
      "<filename> : uncompress a tlog file");

--- a/src/main/arakoon.ml
+++ b/src/main/arakoon.ml
@@ -279,7 +279,7 @@ let main () =
                                   Arg.Set_string filename],
      "<filename> : compress a tlog file");
     ("-archive", Arg.Set_string archive_type,
-     "either '.tlf' or '.tlf'");
+     "either '.tlx' or the older '.tlf'");
     ("--uncompress-tlog", Arg.Tuple[set_laction UncompressTlog;
                                     Arg.Set_string filename],
      "<filename> : uncompress a tlog file");

--- a/src/paxos/sn.ml
+++ b/src/paxos/sn.ml
@@ -22,8 +22,8 @@ let zero = 0L
 let succ t = Int64.succ t
 let pred t = Int64.pred t
 let compare = Int64.compare
-let mul = Int64.mul
-let div = Int64.div
+
+
 let add = Int64.add
 let sub = Int64.sub
 let rem = Int64.rem

--- a/src/tlog/tlog_main.ml
+++ b/src/tlog/tlog_main.ml
@@ -128,13 +128,15 @@ let make_tlog tlog_name (i:int) =
 
 
 let compress_tlog tlu archive_type=
-  let compressor =
-    match archive_type with
-    | ".tls" | "tls" -> Compression.Snappy
-    | _ -> Compression.Bz2
-  in
   let failwith x =
     Printf.ksprintf failwith x in
+  let compressor =
+    match archive_type with
+    | ".tlx"  -> Compression.Snappy
+    | ".tlf"  -> Compression.Bz2
+    | _ -> failwith "invalid archive_type:%s" archive_type
+  in
+  
   let () = if not (Sys.file_exists tlu) then failwith "Input file %s does not exist" tlu in
   let tlx = Tlc2.to_archive_name compressor tlu in
   let () = if Sys.file_exists tlx then failwith "Can't compress %s as %s already exists" tlu tlx in


### PR DESCRIPTION
- correct infimum
- test with size based rollover + collapse + catchup
- change default --compress-tlog
- demand strict increment on a tlog start_i's at startup
