### PR TITLE
sets tlog_max_entries default to 50_000

### DIFF
--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -367,7 +367,7 @@ module Node_cfg = struct
   let _ips inifile node_name =
     Ini.get inifile node_name "ip" Ini.p_string_list Ini.required
 
-  let _tlog_max_entries inifile = _global_int inifile "tlog_max_entries"    10_000
+  let _tlog_max_entries inifile = _global_int inifile "tlog_max_entries"    50_000
   let _tlog_max_size    inifile = _global_int inifile "tlog_max_size"    5_000_000
 
   let _tlog_entries_overwrite inifile =


### PR DESCRIPTION
everybody just uses the default, but the default's a bit too sharp
