### PR TITLE
change default tlog_max_size

### DIFF
--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -367,8 +367,8 @@ module Node_cfg = struct
   let _ips inifile node_name =
     Ini.get inifile node_name "ip" Ini.p_string_list Ini.required
 
-  let _tlog_max_entries inifile = _global_int inifile "tlog_max_entries"    50_000
-  let _tlog_max_size    inifile = _global_int inifile "tlog_max_size"    5_000_000
+  let _tlog_max_entries inifile = _global_int inifile "tlog_max_entries"       50_000
+  let _tlog_max_size    inifile = _global_int inifile "tlog_max_size"    32*1024*1024
 
   let _tlog_entries_overwrite inifile =
     Ini.get inifile "global" "__tainted_tlog_entries_per_file"


### PR DESCRIPTION
In the same spirit as #73 ...
I've seen an nsm under load generate 150 new tlogs per minute ...
Not sure if we need/want to make some alba changes there too, but this reduces the rate of new tlogs by a factor of 6.
