### PR TITLE
update ocaml-redis version

### DIFF
--- a/docker/arakoon_centos7/Dockerfile
+++ b/docker/arakoon_centos7/Dockerfile
@@ -57,7 +57,7 @@ RUN eval `${opam_env}` && \
         conf-libev \
         ocplib-endian \
         depext \
-        redis.0.2.3 \
+        redis.0.3.1 \
         uri.1.9.1 \
         core.113.00.00
 

--- a/docker/arakoon_debian/Dockerfile
+++ b/docker/arakoon_debian/Dockerfile
@@ -66,7 +66,7 @@ RUN eval `${opam_env}` && \
         conf-libev \
         ocplib-endian \
         depext \
-        redis.0.2.3 \
+        redis.0.3.1 \
         uri.1.9.1 \
         core.113.00.00
 

--- a/travis.sh
+++ b/travis.sh
@@ -10,7 +10,7 @@ OPAM_DEPENDS="ssl.0.5.2 \
               snappy \
               quickcheck \
               ocplib-endian \
-              redis.0.2.3 \
+              redis.0.3.1 \
               uri.1.9.1 \
               core.113.00.00
 "


### PR DESCRIPTION
there's a new package, but some server on the internet still has to be synced before this works
(the new version is required by alba)
