### PR TITLE
logging tweaks

### DIFF
--- a/cfg/arakoon.ini
+++ b/cfg/arakoon.ini
@@ -79,6 +79,7 @@ client_protocol = debug
 paxos = debug
 tcp_messaging = debug
 tlog_map = debug
+server = debug
 
 #[default_batched_transaction_config]
 #max_entries = 100    # number of sets and deletes

--- a/src/client/client_protocol.ml
+++ b/src/client/client_protocol.ml
@@ -103,10 +103,14 @@ let handle_exception oc exn=
       | Server.FOOBAR ->
         Lwt.return (Arakoon_exc.E_UNKNOWN_FAILURE, "unkown failure", true, Logger.Error)
       | Canceled ->
-        Lwt.fail Canceled
+         Lwt.fail Canceled
+      | Unix.Unix_error(Unix.ECONNRESET, _, _) ->
+         Lwt.return (Arakoon_exc.E_UNKNOWN_FAILURE,
+                     "ECONNRESET because the client disconnected",
+                    true, Logger.Debug)
       | End_of_file ->
         Lwt.return (Arakoon_exc.E_UNKNOWN_FAILURE, "end of file because the client disconnected",
-                    true, Logger.Info)
+                    true, Logger.Debug)
       | _ ->
         Lwt.return (Arakoon_exc.E_UNKNOWN_FAILURE, "unknown failure", true, Logger.Error)
   end

--- a/src/main/arakoon.ml
+++ b/src/main/arakoon.ml
@@ -165,7 +165,9 @@ let main () =
 
   let () =
     Lwt.async_exception_hook :=
-    (fun exn -> Logger.ign_info_f_ ~exn "Caught async exception")
+      (fun exn -> Logger.ign_info_f_
+                    "Caught async exception: %S"
+                    (Printexc.to_string exn))
   in
   let _ = Bz2.version in
   let () = Lwt_io.set_default_buffer_size 65536 in

--- a/src/msg/tcp_messaging.ml
+++ b/src/msg/tcp_messaging.ml
@@ -396,7 +396,10 @@ class tcp_messaging
         Lwt.catch
           (fun () -> loop (Bytes.create 1024))
           (fun exn ->
-             Logger.info_f_ ~exn "going to drop outgoing connection as well" >>= fun () ->
+            Logger.info_f_
+              "going to drop outgoing connection as well: %S"
+              (Printexc.to_string exn)
+            >>= fun () ->
              self # _drop_connection address >>= fun () ->
              Lwt.fail exn)
       in

--- a/src/node/catchup.ml
+++ b/src/node/catchup.ml
@@ -116,7 +116,8 @@ let catchup_tlog (type s) ~tls_ctx ~tcp_keepalive ~stop other_configs ~cluster_i
       | None ->
          Logger.warning_f_ "catchup tlog from unknown node:%S is config up to date?" mr_name
     )
-    (fun exn -> Logger.warning_ ~exn "catchup_tlog failed")
+    (fun exn -> Logger.warning_f_ "catchup_tlog failed: %S"
+                                  (Printexc.to_string exn))
   >>= fun () ->
   tlog_coll # get_last_i ()
 

--- a/src/node/collapser.ml
+++ b/src/node/collapser.ml
@@ -194,7 +194,11 @@ let _head_i (type s) (module S : Store.STORE with type t = s) ?cluster_id head_l
        Lwt.return head_io
     )
     (fun exn ->
-       Logger.info_f_ ~exn "returning assuming no I %S" head_location >>= fun () ->
+      Logger.info_f_
+        "returning assuming no I %S: %S"
+        head_location
+        (Printexc.to_string exn)
+      >>= fun () ->
        Lwt.return None
     )
 

--- a/src/node/node_cfg.ml
+++ b/src/node/node_cfg.ml
@@ -183,6 +183,7 @@ module Node_cfg = struct
       paxos: string option;
       tcp_messaging: string option;
       tlog_map: string option;
+      server : string option;
     }
 
   let string_of_log_cfg lcfg =
@@ -190,6 +191,7 @@ module Node_cfg = struct
     record [ "client_protocol", option string lcfg.client_protocol
            ; "paxos", option string lcfg.paxos
            ; "tcp_messaging", option string lcfg.tcp_messaging
+           ; "server", option string lcfg.server
            ]
 
   let get_default_log_config () =
@@ -198,6 +200,7 @@ module Node_cfg = struct
       paxos = None;
       tcp_messaging = None;
       tlog_map = None;
+      server = None;
     }
 
   type batched_transaction_cfg =
@@ -461,11 +464,13 @@ module Node_cfg = struct
     let paxos = get_log_level "paxos" in
     let tcp_messaging = get_log_level "tcp_messaging" in
     let tlog_map = get_log_level "tlog_map" in
+    let server = get_log_level "server" in
     {
       client_protocol;
       paxos;
       tcp_messaging;
       tlog_map;
+      server;
     }
 
   let _batched_transaction_config inifile section_name =

--- a/src/node/node_main.ml
+++ b/src/node/node_main.ml
@@ -56,6 +56,7 @@ let _config_log_levels me cluster_cfg cfg =
   let () = set_level Multi_paxos.section log_config.paxos in
   let () = set_level Tcp_messaging.section log_config.tcp_messaging in
   let () = set_level Tlog_map.section log_config.tlog_map in
+  let () = set_level Server.section log_config.server in
   Lwt.return ()
 
 let _config_logging me get_cfgs =
@@ -229,7 +230,11 @@ let only_catchup
        tlc # close () >>= fun () ->
        Lwt.return true)
       (fun exn ->
-       Logger.warning_f_ ~exn "Catchup from %s failed" mr_name >>= fun () ->
+        Logger.warning_f_
+          "Catchup from %s failed: %S"
+          mr_name
+          (Printexc.to_string exn)
+        >>= fun () ->
        Lwt.return false)
   in
   let rec try_nodes = function

--- a/src/system/startup.ml
+++ b/src/system/startup.ml
@@ -37,6 +37,7 @@ let _make_log_cfg () =
      paxos = None;
      tcp_messaging = None;
      tlog_map = None;
+     server = None;
    })
 
 let _make_batched_transaction_cfg () =

--- a/src/tools/network.ml
+++ b/src/tools/network.ml
@@ -72,7 +72,9 @@ let __open_connection ?(ssl_context : [> `Client ] Typed_ssl.t option)
              Lwt.return (socket, ic, oc)
        )
     (fun exn ->
-       Logger.info_f_ ~exn "__open_connection to %s failed" (a2s socket_address)
+      Logger.info_f_ "__open_connection to %s failed: %S"
+                     (a2s socket_address)
+                     (Printexc.to_string exn)
        >>= fun () ->
        Lwt_unix.close socket >>= fun () ->
        Lwt.fail exn)


### PR DESCRIPTION
- more fine grained configuration of connection logging
- replace ~exn with ": %S" (Printexc.to_string exn)