### PR TITLE
back to Lwt.3.0.0

### DIFF
--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -57,7 +57,7 @@ RUN eval `${opam_env}` && \
         snappy \
         bisect \
         lwt_ssl \
-        lwt.3.1.0 \
+        lwt.3.0.0 \
         camltc.0.9.4 \
         ocplib-endian.1.0 \
         quickcheck.1.0.2 \

--- a/docker/ubuntu-14.04/Dockerfile
+++ b/docker/ubuntu-14.04/Dockerfile
@@ -51,7 +51,7 @@ RUN eval `${opam_env}` && \
         snappy \
         bisect \
         lwt_ssl \
-        lwt.3.1.0 \
+        lwt.3.0.0 \
         camltc.0.9.4 \
         ocplib-endian.1.0 \
         quickcheck.1.0.2 \

--- a/docker/ubuntu-16.04/Dockerfile
+++ b/docker/ubuntu-16.04/Dockerfile
@@ -50,7 +50,7 @@ RUN eval `${opam_env}` && \
         snappy \
         bisect \
         lwt_ssl \
-        lwt.3.1.0 \
+        lwt.3.0.0 \
         camltc.0.9.4 \
         ocplib-endian.1.0 \
         quickcheck.1.0.2 \


### PR DESCRIPTION
TLS tests fail with 3.1.0: fe
server.quick.system_tests_ssl.TestTLS.test_inter_node_communication

with Lwt.3.0.0 they succeed again.